### PR TITLE
Fix existing position / existing figure element

### DIFF
--- a/redactorimageposition/resources/js/redactorImagePosition_script.js
+++ b/redactorimageposition/resources/js/redactorImagePosition_script.js
@@ -86,11 +86,20 @@ RedactorPlugins.imagePosition = function () {
             var $image = $(elem);
             var c = $image.data('pos');
             var $caption = ($image.next('figcaption').length > 0) ? $image.next('figcaption') : $image.parent().next('figcaption');
+            var $figure = $image.closest('figure');
 
             if (c !== 'left' && c !== 'right' && c !== 'full') return;
 
-            $image.wrap(this.imagePosition.figureClasses['figureWrap']);
-            var $figure = $image.parent('figure').unwrap();
+            if ($figure.length === 0) {
+                // wrap in <figure> element if not already wrapped
+                $image.wrap(this.imagePosition.figureClasses['figureWrap']);
+                $figure = $image.parent('figure').unwrap();
+            } else {
+                // remove existing positioning on figure
+                $figure.removeClass(this.imagePosition.figureClasses['figureLeft']);
+                $figure.removeClass(this.imagePosition.figureClasses['figureRight']);
+                $figure.removeClass(this.imagePosition.figureClasses['figureFull']);
+            }
 
             $image.addClass(this.imagePosition.figureClasses['imageClass']);
             $caption.addClass(this.imagePosition.figureClasses['captionClass']);

--- a/redactorimageposition/resources/js/redactorImagePosition_script.js
+++ b/redactorimageposition/resources/js/redactorImagePosition_script.js
@@ -49,6 +49,17 @@ RedactorPlugins.imagePosition = function () {
             var $redactorImage = $('#redactor-modal img');
             var src = $redactorImage.attr('src');
             var $bodyImage = $('.redactor-box img[src*="' + src + '"]');
+            var $figure = $bodyImage.closest('figure');
+
+            // get existing figure position
+            if ($figure.hasClass(this.imagePosition.figureClasses['figureLeft'])) {
+                $bodyImage.data('pos', 'left');
+            } else if ($figure.hasClass(this.imagePosition.figureClasses['figureRight'])) {
+                $bodyImage.data('pos', 'right');
+            } else if ($figure.hasClass(this.imagePosition.figureClasses['figureFull'])) {
+                $bodyImage.data('pos', 'full');
+            }
+
             var pos = $bodyImage.data('pos') || 'full';
             var $activePosition = $positions.filter('[data-option*="' + pos +'"]');
 


### PR DESCRIPTION
This fixes a few bugs:

1. When editing an existing positioned image, it defaulted to full even when the existing image had left or right positioning. This pull request makes it so it will derive the existing position from the classes found on the figure element.

2. When changing the positioning of an already positioned image (let's say changing from right positioned to left), the image would get wrapped in two figure elements. This pull request makes it so it checks to see if there's already a figure element before wrapping onModalSave.